### PR TITLE
[py-tx] updated Cli to remove python 3.8 and add python 3.12

### DIFF
--- a/.github/workflows/python-threatexchange-ci.yaml
+++ b/.github/workflows/python-threatexchange-ci.yaml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.11']
+        python-version: ['3.9', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python ${{ matrix.python-version }}


### PR DESCRIPTION
Removed the Python 3.8 CI, and added the Python 3.12 CI.
